### PR TITLE
Added Path Config to the Union Module

### DIFF
--- a/lib/union/Access.js
+++ b/lib/union/Access.js
@@ -1,10 +1,11 @@
 const request = require('./common/request');
+const PATH_CONFIG = require('./pathConfig/path-config');
 
 exports.Token = async data => {
     try {
         return await request.trigger({
             method: 'POST',
-            path: '/union/oauth/token',
+            path: PATH_CONFIG.ACCESS_TOKEN_PATH,
             credentials: { ...data },
             payload: data.payload,
         });

--- a/lib/union/Customer.js
+++ b/lib/union/Customer.js
@@ -1,10 +1,11 @@
 const request = require('./common/request');
+const PATH_CONFIG = require('./pathConfig/path-config');
 
 exports.CustomerEnquiry = async data => {
     try {
         return await request.trigger({
             method: 'POST',
-            path: '/union/secured/cbacustomerenquiry',
+            path: PATH_CONFIG.CUSTOMER_ENQUIRY_PATH,
             credentials: { ...data },
             payload: data.payload,
         });
@@ -17,7 +18,7 @@ exports.CustomerAccountEnquiry = async data => {
     try {
         return await request.trigger({
             method: 'POST',
-            path: '/union/secured/cbacustomeraccountenquiry',
+            path: PATH_CONFIG.CUSTOMER_ACCOUNT_ENQUIRY_PATH,
             credentials: { ...data },
             payload: data.payload,
         });
@@ -30,7 +31,7 @@ exports.AccountEnquiry = async data => {
     try {
         return await request.trigger({
             method: 'POST',
-            path: '/union/secured/cbaaccountenquiry',
+            path: PATH_CONFIG.ACCOUNT_ENQUIRY_PATH,
             credentials: { ...data },
             payload: data.payload,
         });
@@ -43,7 +44,7 @@ exports.ChangeUserCredentials = async data => {
     try {
         return await request.trigger({
             method: 'POST',
-            path: '/union/secured/changeusercredentials',
+            path: PATH_CONFIG.CHANGE_USER_CREDENTIALS_PATH,
             credentials: { ...data },
             payload: data.payload,
         });

--- a/lib/union/pathConfig/path-config.js
+++ b/lib/union/pathConfig/path-config.js
@@ -1,0 +1,9 @@
+const PATH_CONFIG = Object.freeze({
+    ACCESS_TOKEN_PATH: '/union/oauth/token',
+    CUSTOMER_ENQUIRY_PATH: '/union/secured/cbacustomerenquiry',
+    CUSTOMER_ACCOUNT_ENQUIRY_PATH: '/union/secured/cbacustomeraccountenquiry',
+    ACCOUNT_ENQUIRY_PATH: '/union/secured/cbaaccountenquiry',
+    CHANGE_USER_CREDENTIALS_PATH: '/union/secured/changeusercredentials',
+});
+
+module.exports = PATH_CONFIG;


### PR DESCRIPTION
To make the Union package more readable and standard, I added a path config module to store all API endpoints and exposing them via an immutable object, this can be done to other modules too but I am making this for the Union Module first to know the reaction to it before proceeding to the others.